### PR TITLE
Improve pattern wordlist generation performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,5 @@ coverage.xml
 # Sphinx documentation
 docs/_build/
 
+.idea/
+

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Generate all the possible words with length within a given interval (e.g. from 2
 
 Generate following a given pattern:
 
-    $ wordlist [charset] @@q@@er@t@y
+    $ wordlist [charset] {}{}q{}{}er{}t@y
 
 Save a list to file:
 
@@ -69,7 +69,7 @@ Generate following a given pattern:
 ```python
 import wordlist
 generator = wordlist.Generator('charset')
-for each in generator.generate_with_pattern('@@q@@er@t@y'):
+for each in generator.generate_with_pattern('{}{}q{}{}er{}t{}y'):
     print(each)
 ```
 
@@ -86,10 +86,12 @@ There are to ways to pass the charset to the script:
 #### Pattern
 The pattern should be like:
 
-`@@q@@er@t@y`
+`{}{}q{}{}er{}t{}y`
 
-The script will replace every `@` symbol with every letter in the charset so as to get every possible
+The script will replace every `{}` symbol with every letter in the charset so as to get every possible
 permutation. Every other symbol will be a fixed character present in every string. In this example, every generated string will contain a `q` at the 3rd position an `e` at the 6th and so on.
+
+If you need to scape the curly brackets in the pattern just use `{{}}`
 
 ## Contributing
 

--- a/tests/generator_tests.py
+++ b/tests/generator_tests.py
@@ -57,9 +57,9 @@ def test_generate_4():
 
 
 def test_generate_with_pattern():
-    print("testing wordlist.Generator(\"ab\").generate_with_pattern(\"@@\")")
+    print("testing wordlist.Generator(\"ab\").generate_with_pattern(\"{}{}\")")
     gen = wordlist.Generator("ab")
-    c = gen.generate_with_pattern('@@')
+    c = gen.generate_with_pattern('{}{}')
     assert_equals(next(c), 'aa')
     assert_equals(next(c), 'ab')
     assert_equals(next(c), 'ba')
@@ -69,9 +69,9 @@ def test_generate_with_pattern():
 
 
 def test_generate_with_pattern_2():
-    print("testing wordlist.Generator(\"ab\").generate_with_pattern(\"@a\")")
+    print("testing wordlist.Generator(\"ab\").generate_with_pattern(\"{}a\")")
     gen = wordlist.Generator("ab")
-    c = gen.generate_with_pattern('@a')
+    c = gen.generate_with_pattern('{}a')
     assert_equals(next(c), 'aa')
     assert_equals(next(c), 'ba')
     with assert_raises(StopIteration):
@@ -79,9 +79,9 @@ def test_generate_with_pattern_2():
 
 
 def test_generate_with_pattern_3():
-    print("testing wordlist.Generator(\"ab\").generate_with_pattern(\"a@\")")
+    print("testing wordlist.Generator(\"ab\").generate_with_pattern(\"a{}\")")
     gen = wordlist.Generator("ab")
-    c = gen.generate_with_pattern('a@')
+    c = gen.generate_with_pattern('a{}')
     assert_equals(next(c), 'aa')
     assert_equals(next(c), 'ab')
     with assert_raises(StopIteration):
@@ -89,9 +89,9 @@ def test_generate_with_pattern_3():
 
 
 def test_generate_with_pattern_4():
-    print("testing wordlist.Generator(\"ab\").generate_with_pattern(\"a@b\")")
+    print("testing wordlist.Generator(\"ab\").generate_with_pattern(\"a{}b\")")
     gen = wordlist.Generator("ab")
-    c = gen.generate_with_pattern('a@b')
+    c = gen.generate_with_pattern('a{}b')
     assert_equals(next(c), 'aab')
     assert_equals(next(c), 'abb')
     with assert_raises(StopIteration):

--- a/wordlist/__init__.py
+++ b/wordlist/__init__.py
@@ -25,5 +25,5 @@ ba
 from .wordlist import Generator
 
 __title__ = "wordlist"
-__version__ = '1.0.1'
+__version__ = '1.0.3'
 __all__ = ["Generator"]

--- a/wordlist/_util.py
+++ b/wordlist/_util.py
@@ -36,10 +36,8 @@ def parse_charset(charset):
     return charset
 
 
-def scan_pattern(string):
+def get_pattern_length(string):
     """
-    Scans the pattern in the form @@@a@@ returning an OrderedDict
-    containing the position of the fixed characters.
+    Determines the number of characters to be filled in the pattern
     """
-    res = OrderedDict([(i, x) for i, x in enumerate(string) if x != '@'])
-    return res
+    return string.replace("{{}}", "").count("{}")

--- a/wordlist/wordlist.py
+++ b/wordlist/wordlist.py
@@ -15,10 +15,9 @@ Generates all possible permutations of a given charset.
 from __future__ import print_function
 
 from itertools import product
-from collections import OrderedDict
 
 from ._util import (parse_charset,
-                    scan_pattern)
+                    get_pattern_length)
 
 
 class Generator(object):
@@ -44,49 +43,17 @@ class Generator(object):
                 # yield the produced word
                 yield ''.join(each)+self.delimiter
 
-    def generate_with_pattern(self, pattern=None, data=None, composed='',
-                              prev=0):
+    def generate_with_pattern(self, pattern=None):
         """
-        Iterative-Recursive algorithm that creates the list
+        Algorithm that creates the list
         based on a given pattern
-        Each recursive call will concatenate a piece of string
-        to the composed parameter
-        data contains the dict created by scanning the pattern
-        composed contains the current composed word (works recursively)
-        prev is the index of the previous data object used.
+        The pattern must be like string format patter:
+        e.g: a{}b will match an 'a' follow by any character follow by a 'b'
+
+        To scape the curly brackets just use {{}}
         """
-        if pattern:
-            if not prev:
-                # the first call should scan the pattern first
-                data = scan_pattern(pattern)
 
-            if not data:
-                # if the known values in the pattern have been completely
-                # used concat the last part, if any, and print it out
-                diff = len(pattern)-prev
-                if diff and composed:
-                    for word in product(self.charset, repeat=diff):
-                         # yield the produced word
-                        c_word = ''.join(composed) + ''.join(word)
-                        yield c_word + self.delimiter
-
-                elif diff:
-                    for word in product(self.charset, repeat=diff):
-                         # yield the produced word
-                        yield ''.join(word) + self.delimiter
-                else:
-                     # yield the produced word
-                    yield ''.join(composed) + self.delimiter
-            else:
-                # pop a value from the pattern dict concat it to composed
-                # concat a new part to the composed string and call this
-                # function again with the new composed word
-                num, val = data.popitem(last=False)
-                for word in product(self.charset, repeat=(num-prev)):
-                    tmp_composed = ''.join(composed) + ''.join(word) + val
-                    gen = self.generate_with_pattern(pattern=pattern,
-                                                     data=OrderedDict(data),
-                                                     composed=tmp_composed,
-                                                     prev=num+1)
-                    for word in gen:
-                        yield word
+        curlen = get_pattern_length(pattern)
+        str_generator = product(self.charset, repeat=curlen)
+        for each in str_generator:
+            yield pattern.format(*each)+self.delimiter


### PR DESCRIPTION
Is better to watch it:

Before
```
$ time ./bin/wordlist abcdefghijklmnopqrstuvwxyz1234567890 a@@@@c | wc -l
1679616

real	0m12.495s
user	0m12.482s
sys	0m0.050s
```

After
```
$ time ./bin/wordlist abcdefghijklmnopqrstuvwxyz1234567890 a{}{}{}{}c | wc -l
1679616

real	0m0.789s
user	0m0.797s
sys	0m0.041s

```
